### PR TITLE
ASYCUDA project build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+## Local config / build outputs
+build/custom.properties
+build/platform.properties
+release/
+
+## Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # busingebrian.io
+
+This repository currently contains a small Node/Express server (`server.js`) and static HTML/CSS/JS assets.
+
+## ASYCUDA PDK build (SOClass / EMS)
+
+Before building ASYCUDA, first install:
+
+- **SOClass Server**
+- **SOClass Client**
+- **SOClass ADK**
+- **SOClass Report**
+- **SOClass VectorGraphics**
+
+### Steps to build
+
+1. Create `build/custom.properties` from `build/custom.properties.template` (see comments inside the template).
+2. Create `build/platform.properties` from `build/platform.properties.template` (see comments inside the template).
+3. Execute:
+
+```bash
+ant createPDK
+```
+
+In folder `release/` is placed the PDK of ASYCUDA. You can then:
+
+- Go to `release/` and run `java -jar setup.jar`
+- Archive/burn/send that folder to the production system and run `java -jar setup.jar` to install ASYCUDA on:
+  - SOClass server
+  - SOClass client
+  - or deploy ULA / create End User Client Setup (prepares a folder to deploy client jars and reference tables)
+
+### EMS version notes
+
+ASYCUDA is built for **EMS 1.4.0.3** (SOClass up to **2.2.31**).
+
+To build for EMS **1.5** or **1.6** (SOClass **2.2.31+**):
+
+- Uncomment `so.ems.version` in `build/custom.properties`, or invoke:
+
+```bash
+ant -Dso.ems.version=1.5 createPDK
+```
+

--- a/build/custom.properties.template
+++ b/build/custom.properties.template
@@ -1,0 +1,22 @@
+##
+# ASYCUDA build customization properties (template)
+#
+# Instructions:
+# - Copy this file to: build/custom.properties
+# - Edit values to match your SOClass/EMS installation and desired build output.
+#
+# Note:
+# - ASYCUDA is built for EMS 1.4.0.3 by default (SOClass up to 2.2.31).
+# - For EMS 1.5 or 1.6 (SOClass 2.2.31+), set `so.ems.version` or pass it on the command line:
+#     ant -Dso.ems.version=1.5 createPDK
+##
+
+# Optional override. Uncomment to build against a different EMS version.
+# so.ems.version=1.4
+
+# Example placeholders (adjust/remove to match your actual Ant build scripts):
+# so.home=/opt/soclass
+# so.server.home=/opt/soclass/server
+# so.client.home=/opt/soclass/client
+# so.adk.home=/opt/soclass/adk
+

--- a/build/platform.properties.template
+++ b/build/platform.properties.template
@@ -1,0 +1,13 @@
+##
+# Platform-specific properties (template)
+#
+# Instructions:
+# - Copy this file to: build/platform.properties
+# - Edit values to match the machine where you run the build (paths, tools, etc).
+##
+
+# Example placeholders (adjust/remove to match your actual Ant build scripts):
+# java.home=/usr/lib/jvm/java-17-openjdk
+# ant.home=/usr/share/ant
+# tmp.dir=/tmp
+

--- a/docs/ASYCUDA_PDK_BUILD.md
+++ b/docs/ASYCUDA_PDK_BUILD.md
@@ -1,0 +1,59 @@
+## Prerequisites (SOClass)
+
+Before building ASYCUDA, first install:
+
+- **SOClass Server**
+- **SOClass Client**
+- **SOClass ADK**
+- **SOClass Report**
+- **SOClass VectorGraphics**
+
+These components are vendor-provided installers and are not distributed with this repository.
+
+## Build steps
+
+1. Create `build/custom.properties` using the template file `build/custom.properties.template` (follow the comments in the template).
+2. Create `build/platform.properties` using the template file `build/platform.properties.template` (follow the comments in the template).
+3. Execute:
+
+```bash
+ant createPDK
+```
+
+## Output: PDK in `release/`
+
+After the build completes, the `release/` folder contains the PDK of ASYCUDA. You can then:
+
+### Install locally
+
+- Go to `release/` and run:
+
+```bash
+java -jar setup.jar
+```
+
+### Deploy to production
+
+- Archive/burn/send the `release/` folder to the production system and run:
+
+```bash
+java -jar setup.jar
+```
+
+This installs ASYCUDA on SOClass server, SOClass client, or can be used to:
+
+- deploy ULA, or
+- create **End User Client Setup** (prepares a folder used to deploy client jars and reference tables on client computers)
+
+## EMS compatibility
+
+ASYCUDA is built for **EMS 1.4.0.3** (SOClass up to **2.2.31**).
+
+To build ASYCUDA for EMS **1.5** or **1.6** (SOClass **2.2.31+**):
+
+- Uncomment `so.ems.version` in `build/custom.properties`, or invoke:
+
+```bash
+ant -Dso.ems.version=1.5 createPDK
+```
+


### PR DESCRIPTION
Add ASYCUDA PDK build documentation and template files to align the repository with provided build instructions.

The repository was missing the `build/` directory, `custom.properties.template`, `platform.properties.template`, and clear build instructions in the `README.md` as described in the user's task. This PR adds these missing artifacts and documentation to facilitate the ASYCUDA PDK build process.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6dada176-3fd7-4630-a7ed-84a5dcfd3c50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6dada176-3fd7-4630-a7ed-84a5dcfd3c50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

