### PR TITLE
Docker without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # busingebrian.io
+
+## Docker without `sudo` (Linux)
+
+If you currently have to run `sudo docker ...`, you can enable running Docker as your normal user.
+
+### Option A: Add your user to the `docker` group (most common)
+
+Run:
+
+```bash
+sudo groupadd docker 2>/dev/null || true
+sudo usermod -aG docker "$USER"
+
+# Apply new group membership (choose ONE):
+newgrp docker
+# or log out and log back in
+```
+
+Then verify:
+
+```bash
+docker run --rm hello-world
+```
+
+### Option B: Rootless Docker (more locked-down environments)
+
+If you prefer not to grant your user access to the Docker daemon socket, use rootless Docker instead.
+Follow Docker’s rootless setup docs (distro-specific).
+
+### Helper script
+
+This repo includes:
+
+```bash
+./scripts/docker-without-sudo.sh
+```
+
+It configures Option A and prints the next steps to apply the change.

--- a/scripts/docker-without-sudo.sh
+++ b/scripts/docker-without-sudo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  echo "Do not run this script as root. Run it as your normal user." >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is not installed or not on PATH." >&2
+  echo "Install Docker Engine first, then re-run this script." >&2
+  exit 1
+fi
+
+echo "Configuring Docker to run without sudo (docker group method)."
+echo
+
+if getent group docker >/dev/null 2>&1; then
+  echo "- docker group already exists"
+else
+  echo "- creating docker group (requires sudo)"
+  sudo groupadd docker
+fi
+
+echo "- adding user '$USER' to docker group (requires sudo)"
+sudo usermod -aG docker "$USER"
+
+echo
+echo "Done. Group membership changes require a NEW login session."
+echo
+echo "Next step (choose one):"
+echo "  - Log out and log back in"
+echo "  - Or run: newgrp docker"
+echo
+echo "Then verify with:"
+echo "  docker run --rm hello-world"
+


### PR DESCRIPTION
Add a guide and helper script to enable running Docker commands without `sudo` for improved developer convenience.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f01a2ee0-038b-4398-8e47-a4e014d7b08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f01a2ee0-038b-4398-8e47-a4e014d7b08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

