### PR TITLE
Maven dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # busingebrian.io
+
+## Notes
+
+### Maven dependency resolution (internal SNAPSHOT artifacts)
+
+If you see errors like:
+
+- `Could not find artifact ug.go.ura.domain.utility:ura-domain-service:jar:1.0-SNAPSHOT`
+- `Could not find artifact ug.go.ura.domain.utility:ura-application-service:jar:1.0-SNAPSHOT`
+
+…those artifacts are **not in Maven Central**, so Maven can only resolve them if:
+
+- you build/install them locally (reactor build / `mvn install`), or
+- you have access to an internal Maven repository (Nexus/Artifactory/GitHub Packages) that hosts them.
+
+See `docs/maven/internal-snapshot-deps.md` for concrete fix options (including a helper install script).

--- a/docs/maven/internal-snapshot-deps.md
+++ b/docs/maven/internal-snapshot-deps.md
@@ -1,0 +1,109 @@
+# Resolving missing internal SNAPSHOT dependencies (Maven)
+
+This is what the error usually means:
+
+> `Could not find artifact ug.go.ura.domain.utility:ura-domain-service:jar:1.0-SNAPSHOT`
+
+`ug.go.ura.domain.utility:*` is an **internal** coordinate, so Maven will not find it in Maven Central unless your organization publishes it to an accessible repository.
+
+---
+
+## Option A (preferred): resolve from an internal Maven repo (Nexus/Artifactory/GitHub Packages)
+
+### 1) Add a snapshots repository (if the project POM doesn’t already have one)
+
+Add this to the POM that declares the dependency (or the parent POM if you have one):
+
+```xml
+<repositories>
+  <repository>
+    <id>ura-snapshots</id>
+    <url>https://YOUR_NEXUS_OR_ARTIFACTORY_HOST/repository/maven-snapshots/</url>
+    <releases>
+      <enabled>false</enabled>
+    </releases>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+```
+
+If the repo also hosts releases, add a second `<repository>` entry for releases (or enable releases in the same repo entry, if that’s how your repo is set up).
+
+### 2) Configure credentials in `~/.m2/settings.xml` (if required)
+
+If the repository requires auth, add:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>ura-snapshots</id>
+      <username>${env.MAVEN_REPO_USERNAME}</username>
+      <password>${env.MAVEN_REPO_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Make sure the `<id>` matches the repository `<id>` in the POM.
+
+### 3) Force Maven to re-check SNAPSHOTs
+
+```bash
+mvn -U clean verify
+```
+
+If Maven cached a “not found”, delete the cached directory and retry:
+
+```bash
+rm -rf ~/.m2/repository/ug/go/ura/domain/utility
+mvn -U clean verify
+```
+
+---
+
+## Option B: build and install those artifacts locally (reactor / local install)
+
+If you have the source code for:
+
+- `ug.go.ura.domain.utility:ura-domain-service:1.0-SNAPSHOT`
+- `ug.go.ura.domain.utility:ura-application-service:1.0-SNAPSHOT`
+
+Build and install them into your local Maven repo:
+
+```bash
+cd /path/to/ura-domain-utility
+mvn -DskipTests install
+```
+
+Then build your `api` module again.
+
+---
+
+## Option C: you only have JAR files (install into `~/.m2` from disk)
+
+If your team shares the JARs but not a Maven repository, you can install them into your local Maven repo with:
+
+- `scripts/maven/install-ura-domain-utility.sh`
+
+Example:
+
+```bash
+./scripts/maven/install-ura-domain-utility.sh /path/to/jars
+```
+
+The script expects these filenames by default:
+
+- `ura-domain-service-1.0-SNAPSHOT.jar`
+- `ura-application-service-1.0-SNAPSHOT.jar`
+
+---
+
+## Quick checklist
+
+- Is `1.0-SNAPSHOT` the correct version, and does it exist in the internal repo?
+- Are you building from the project root (so all modules are in the Maven reactor), or only from `api/`?
+- Are your `<repositories>` and `~/.m2/settings.xml` `server` ids aligned?
+- Did you try `mvn -U` and clearing the cached “not found” directory?

--- a/scripts/maven/install-ura-domain-utility.sh
+++ b/scripts/maven/install-ura-domain-utility.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GROUP_ID="ug.go.ura.domain.utility"
+VERSION="1.0-SNAPSHOT"
+
+usage() {
+  cat <<'EOF'
+Installs internal URA domain utility JARs into your local Maven repo (~/.m2).
+
+Usage:
+  ./scripts/maven/install-ura-domain-utility.sh /path/to/jars
+
+Expected filenames in the provided directory:
+  ura-domain-service-1.0-SNAPSHOT.jar
+  ura-application-service-1.0-SNAPSHOT.jar
+
+Notes:
+  - This is a stopgap when you don't have a Maven repository (Nexus/Artifactory).
+  - Prefer using an internal Maven repo or building these artifacts from source.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+JAR_DIR="${1:-}"
+if [[ -z "${JAR_DIR}" ]]; then
+  echo "ERROR: missing JAR directory argument."
+  echo
+  usage
+  exit 2
+fi
+
+if [[ ! -d "${JAR_DIR}" ]]; then
+  echo "ERROR: not a directory: ${JAR_DIR}"
+  exit 2
+fi
+
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "ERROR: mvn not found. Install Maven and retry."
+  exit 127
+fi
+
+install_jar() {
+  local artifact_id="$1"
+  local jar_path="$2"
+
+  if [[ ! -f "${jar_path}" ]]; then
+    echo "ERROR: missing file: ${jar_path}"
+    exit 2
+  fi
+
+  mvn -q \
+    org.apache.maven.plugins:maven-install-plugin:3.1.1:install-file \
+    -Dfile="${jar_path}" \
+    -DgroupId="${GROUP_ID}" \
+    -DartifactId="${artifact_id}" \
+    -Dversion="${VERSION}" \
+    -Dpackaging=jar \
+    -DgeneratePom=true
+}
+
+install_jar "ura-domain-service" "${JAR_DIR}/ura-domain-service-${VERSION}.jar"
+install_jar "ura-application-service" "${JAR_DIR}/ura-application-service-${VERSION}.jar"
+
+echo "Installed:"
+echo "  ${GROUP_ID}:ura-domain-service:${VERSION}"
+echo "  ${GROUP_ID}:ura-application-service:${VERSION}"


### PR DESCRIPTION
Add documentation and a helper script to resolve internal Maven SNAPSHOT dependencies.

This PR addresses the `ArtifactNotFoundException` for `ura-domain-service` and `ura-application-service` by providing a guide on how to resolve such issues (e.g., by configuring repositories or installing JARs manually) and includes a script for installing the specific missing JARs into the local Maven repository.

---
<p><a href="https://cursor.com/agents/bc-2c7154ed-87e3-41bb-b6e9-950e8f45e4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c7154ed-87e3-41bb-b6e9-950e8f45e4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

